### PR TITLE
feat: add usage history and current usage endpoints

### DIFF
--- a/internal/api/messages/messages.go
+++ b/internal/api/messages/messages.go
@@ -1,6 +1,9 @@
 package messages
 
-import "time"
+import (
+	"github.com/go-openapi/strfmt"
+	"time"
+)
 
 type (
 	SubscriptionPlanPeriod string
@@ -30,6 +33,7 @@ type SubscriptionPlan struct {
 	Upload     uint64                 `json:"upload"`
 	Download   uint64                 `json:"download"`
 	Status     SubscriptionPlanStatus `json:"status"`
+	StartDate  *strfmt.DateTime       `json:"start_date;omitempty"`
 }
 type SubscriptionResponse struct {
 	Plan        *SubscriptionPlan `json:"plan"`
@@ -71,4 +75,15 @@ type EphemeralKeyResponse struct {
 
 type RequestPaymentMethodChangeResponse struct {
 	ClientSecret string `json:"client_secret"`
+}
+
+type UsageData struct {
+	Date  time.Time `json:"date"`
+	Usage uint64    `json:"usage"`
+}
+
+type CurrentUsageResponse struct {
+	Upload   uint64 `json:"upload"`
+	Download uint64 `json:"download"`
+	Storage  uint64 `json:"storage"`
 }

--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -521,6 +521,7 @@ func (b *BillingServiceDefault) GetSubscription(ctx context.Context, userID uint
 				Storage:    plan.Storage,
 				Upload:     plan.Upload,
 				Download:   plan.Download,
+				StartDate:  &sub.StartDate,
 			}
 
 			cfState, err := b.getCustomField(ctx, sub.SubscriptionID, pendingCustomField)

--- a/service/quota.go
+++ b/service/quota.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"go.lumeweb.com/portal-plugin-billing/internal/api/messages"
 	"go.lumeweb.com/portal-plugin-billing/internal/service"
 	"go.lumeweb.com/portal/core"
 )
@@ -28,6 +29,18 @@ type QuotaService interface {
 
 	// Reconcile reconciles the quota usage for the previous day
 	Reconcile() error
+
+	// GetCurrentUsage retrieves the current usage for a user
+	GetCurrentUsage(userID uint) (*messages.CurrentUsageResponse, error)
+
+	// GetUploadUsageHistory retrieves the upload usage history for a user for the specified number of days
+	GetUploadUsageHistory(userID uint, days int) ([]*messages.UsageData, error)
+
+	// GetDownloadUsageHistory retrieves the download usage history for a user for the specified number of days
+	GetDownloadUsageHistory(userID uint, days int) ([]*messages.UsageData, error)
+
+	// GetStorageUsageHistory retrieves the storage usage history for a user for the specified number of days
+	GetStorageUsageHistory(userID uint, days int) ([]*messages.UsageData, error)
 }
 
 var _ QuotaService = (*service.QuotaServiceDefault)(nil)


### PR DESCRIPTION
This commit introduces new functionality for retrieving usage history and current usage data for users. It includes the following changes:

- Add new API endpoints for getting current usage and usage history
- Implement methods in the QuotaService to fetch usage data
- Update the QuotaService interface with new methods
- Add new message types for usage data responses
- Include start date in subscription plan response