### PR TITLE
refactor: add support for free plans and paid plans toggle

### DIFF
--- a/billing.go
+++ b/billing.go
@@ -25,7 +25,11 @@ func init() {
 			if billingConfig.Enabled {
 				builder.AddFeatureFlag("billing", true)
 
-				if billingConfig.FreePlan != "" {
+				if billingConfig.PaidPlansEnabled {
+					builder.AddFeatureFlag("paid_billing", true)
+				}
+
+				if billingConfig.FreeStorage > 0 || billingConfig.FreeDownload > 0 || billingConfig.FreeUpload > 0 {
 					builder.AddFeatureFlag("free_plan", true)
 				}
 			}

--- a/internal/api/messages/messages.go
+++ b/internal/api/messages/messages.go
@@ -34,6 +34,7 @@ type SubscriptionPlan struct {
 	Download   uint64                 `json:"download"`
 	Status     SubscriptionPlanStatus `json:"status"`
 	StartDate  *strfmt.DateTime       `json:"start_date;omitempty"`
+	IsFree     bool                   `json:"is_free,omitempty"`
 }
 type SubscriptionResponse struct {
 	Plan        *SubscriptionPlan `json:"plan"`

--- a/internal/config/billing.go
+++ b/internal/config/billing.go
@@ -9,15 +9,24 @@ var _ config.Defaults = (*BillingConfig)(nil)
 var _ config.Validator = (*BillingConfig)(nil)
 
 type BillingConfig struct {
-	Enabled     bool              `mapstructure:"enabled"`
-	KillBill    KillBillConfig    `mapstructure:"kill_bill"`
-	Hyperswitch HyperswitchConfig `mapstructure:"hyperswitch"`
-	FreePlan    string            `mapstructure:"free_plan"`
+	Enabled          bool              `mapstructure:"enabled"`
+	PaidPlansEnabled bool              `mapstructure:"paid_plans_enabled"`
+	KillBill         KillBillConfig    `mapstructure:"kill_bill"`
+	Hyperswitch      HyperswitchConfig `mapstructure:"hyperswitch"`
+	FreePlanName     string            `mapstructure:"free_plan_name"`
+	FreeStorage      uint64            `mapstructure:"free_storage"`
+	FreeUpload       uint64            `mapstructure:"free_upload"`
+	FreeDownload     uint64            `mapstructure:"free_download"`
 }
 
 func (c BillingConfig) Defaults() map[string]any {
 	return map[string]any{
-		"enabled": false,
+		"enabled":            false,
+		"paid_plans_enabled": false,
+		"free_plan_name":     "Free",
+		"free_storage":       0,
+		"free_upload":        0,
+		"free_download":      0,
 	}
 }
 
@@ -26,40 +35,38 @@ func (c BillingConfig) Validate() error {
 		return nil
 	}
 
-	if c.KillBill.APIServer == "" {
-		return errors.New("billing.kill_bill.api_server is required")
-	}
+	if c.PaidPlansEnabled {
+		if c.KillBill.APIServer == "" {
+			return errors.New("billing.kill_bill.api_server is required")
+		}
 
-	if c.KillBill.Username == "" {
-		return errors.New("billing.kill_bill.username is required")
-	}
+		if c.KillBill.Username == "" {
+			return errors.New("billing.kill_bill.username is required")
+		}
 
-	if c.KillBill.Password == "" {
-		return errors.New("billing.kill_bill.password is required")
-	}
+		if c.KillBill.Password == "" {
+			return errors.New("billing.kill_bill.password is required")
+		}
 
-	if c.KillBill.APIKey == "" {
-		return errors.New("billing.kill_bill.api_key is required")
-	}
+		if c.KillBill.APIKey == "" {
+			return errors.New("billing.kill_bill.api_key is required")
+		}
 
-	if c.KillBill.APISecret == "" {
-		return errors.New("billing.kill_bill.api_secret is required")
-	}
+		if c.KillBill.APISecret == "" {
+			return errors.New("billing.kill_bill.api_secret is required")
+		}
 
-	if c.Hyperswitch.APIServer == "" {
-		return errors.New("billing.hyperswitch.api_server is required")
-	}
+		if c.Hyperswitch.APIServer == "" {
+			return errors.New("billing.hyperswitch.api_server is required")
+		}
 
-	if c.Hyperswitch.APIKey == "" {
-		return errors.New("billing.hyperswitch.api_key is required")
-	}
+		if c.Hyperswitch.APIKey == "" {
+			return errors.New("billing.hyperswitch.api_key is required")
+		}
 
-	if c.Hyperswitch.PublishableKey == "" {
-		return errors.New("billing.hyperswitch.publishable_key is required")
-	}
-
-	if c.FreePlan == "" {
-		return errors.New("billing.free_plan is required")
+		if c.Hyperswitch.PublishableKey == "" {
+			return errors.New("billing.hyperswitch.publishable_key is required")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This commit introduces the following changes:

1. Add a new configuration option `paid_plans_enabled` to control paid plan features.
2. Implement a free plan with configurable storage, upload, and download limits.
3. Update billing service to handle free plans and paid plans separately.
4. Modify quota calculations to work with both free and paid plans.
5. Add `is_free` flag to subscription plan response.
6. Implement `CancelSubscription` method to handle subscription cancellation.
7. Add `slugify` function to generate plan identifiers.
8. Update various billing-related methods to check for paid plans enablement.